### PR TITLE
If the current link href is empty, use the current window location href

### DIFF
--- a/trackomatic.js
+++ b/trackomatic.js
@@ -342,7 +342,7 @@ function Trackomatic(tracker, config) {
           return url.replace(/^https?:\/\//, '').split('/')[0]
         }
         var getVisitData = function(event, link) {
-          var url           = link.href
+          var url           = link.href === "" ? window.location.href : link.href
           var differentHost = getHost(url) !== getHost(window.location.href)
           var rightClick    = event.which === 3
           var metaKey       = event.ctrlKey || event.metaKey || event.altKey

--- a/trackomatic.js
+++ b/trackomatic.js
@@ -342,7 +342,7 @@ function Trackomatic(tracker, config) {
           return url.replace(/^https?:\/\//, '').split('/')[0]
         }
         var getVisitData = function(event, link) {
-          var url           = link.href === "" ? window.location.href : link.href
+          var url           = link.href || window.location.href
           var differentHost = getHost(url) !== getHost(window.location.href)
           var rightClick    = event.which === 3
           var metaKey       = event.ctrlKey || event.metaKey || event.altKey


### PR DESCRIPTION
This fixes an issue that @awavering was having.
